### PR TITLE
feat(PE): Add new PE module for RTL

### DIFF
--- a/rtl/mac.v
+++ b/rtl/mac.v
@@ -1,0 +1,28 @@
+// ===================== MODULE: mac_unit =====================
+module mac_unit #(parameter n = 8, parameter SUM_WIDTH = (n*2)+4)(
+    input clk,
+    input rst,
+    input signed [n-1:0] xin,
+    input signed [n-1:0] win,
+    input signed [SUM_WIDTH-1:0] acc_in,
+    output reg signed [SUM_WIDTH-1:0] mac_out,
+    output signed [n-1:0] xout
+);
+
+    wire signed [SUM_WIDTH-1:0] product;
+    assign product = xin * win;
+
+    always @(posedge clk or posedge rst) begin
+        if (rst)
+            mac_out <= 0;
+        else
+            mac_out <= product + acc_in;
+    end
+
+    register #(.WIDTH(n)) x_reg (
+        .clk(clk),
+        .rst(rst),
+        .data_in(xin),
+        .data_out(xout)
+    );
+endmodule

--- a/rtl/pe.v
+++ b/rtl/pe.v
@@ -1,0 +1,61 @@
+// ===================== MODULE: PE =====================
+module PE #(parameter n = 16, parameter SUM_WIDTH = (n*2)+4) (
+    input clk,
+    input rst,
+    input signed [n-1:0] xin,
+    input signed [n*7-1:0] win,
+    output signed [SUM_WIDTH-1:0] sum,
+    output signed [SUM_WIDTH-1:0] sum1,
+    output signed [n-1:0] xout
+);
+
+    wire signed [SUM_WIDTH-1:0] mac_out[0:6];
+    wire signed [n-1:0] x_reg[0:6];
+    wire signed [SUM_WIDTH-1:0] acc_chain[0:7];
+
+    assign acc_chain[0] = 0;
+
+    genvar i;
+    generate
+        for (i = 0; i < 7; i = i + 1) begin : MAC_CHAIN
+            wire signed [n-1:0] win_i = win[(i+1)*n-1 -: n];
+
+            if (i == 0) begin
+                mac_unit #(.n(n), .SUM_WIDTH(SUM_WIDTH)) MAC (
+                    .clk(clk),
+                    .rst(rst),
+                    .xin(xin),
+                    .win(win_i),
+                    .acc_in(acc_chain[i]),
+                    .mac_out(mac_out[i]),
+                    .xout(x_reg[i])
+                );
+            end else begin
+                mac_unit #(.n(n), .SUM_WIDTH(SUM_WIDTH)) MAC (
+                    .clk(clk),
+                    .rst(rst),
+                    .xin(x_reg[i-1]),
+                    .win(win_i),
+                    .acc_in(acc_chain[i]),
+                    .mac_out(mac_out[i]),
+                    .xout(x_reg[i])
+                );
+            end
+
+            assign acc_chain[i+1] = mac_out[i];
+        end
+    endgenerate
+
+    assign sum = mac_out[6];
+    assign sum1 = mac_out[5];
+
+    reg signed [n-1:0] xout_reg;
+    always @(posedge clk or posedge rst) begin
+        if (rst)
+            xout_reg <= 0;
+        else
+            xout_reg <= x_reg[6];
+    end
+    assign xout = xout_reg;
+
+endmodule

--- a/rtl/register.v
+++ b/rtl/register.v
@@ -1,0 +1,16 @@
+// ===================== MODULE: register =====================
+module register #(parameter WIDTH = 8) (
+    input clk,
+    input rst,
+    input signed [WIDTH - 1:0] data_in,
+    output reg signed [WIDTH - 1:0] data_out
+);
+
+    always @(posedge clk) begin
+        if (rst) begin
+            data_out <= {WIDTH{1'b0}};
+        end else begin
+            data_out <= data_in;
+        end
+    end
+endmodule


### PR DESCRIPTION
## Summary
This PR adds the PE (Processing Element) module that performs 1x7 convolution or FC layer MAC computation using a MAC chain structure.

## Changes
- `rtl/PE.v`: Implements chained MAC operations using `mac_unit` and `register`
- Outputs: `sum`, `sum1`, and delayed `xout`
- Parameterized with `n` and `SUM_WIDTH`

## Test
✅ Verified with `tb/tb_pe.v` using pattern-based testbench  
✅ Confirmed expected output values for `sum` and `sum1` match Python reference

## Next Steps
- Connect PE to ReLU in `feature/rtl-top`
