### PR TITLE
feat(tb): add testbenches to test all module rtl design

### DIFF
--- a/tb/tb_control_buffer.v
+++ b/tb/tb_control_buffer.v
@@ -1,0 +1,146 @@
+`timescale 1ns/1ps
+
+`define PATTERN_FILE "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/control_buffer_pattern.txt"
+`define RESULT_FILE "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/control_buffer_results.txt"
+`define NUM_PATTERNS 100
+
+module control_buffer_tb;
+    localparam WIDTH = 32;
+
+    reg clk, rst;
+    reg signed [WIDTH-1:0] data_in;
+    reg [1:0] S5, S6;
+    wire signed [WIDTH-1:0] data_out;
+
+    integer fd_in, fd_out, i;
+    integer err_count = 0;
+    integer j;
+
+    reg signed [WIDTH-1:0] pipe[0:53];
+
+    reg signed [WIDTH-1:0] data_queue[0:99];
+    reg [1:0] S5_queue[0:99], S6_queue[0:99];
+    integer delay_queue[0:99];
+    integer q_head = 0, q_tail = 0;
+
+    reg signed [WIDTH-1:0] expected_out;
+    integer local_delay;
+
+    ControlBuffer #(.WIDTH(WIDTH)) dut (
+        .clk(clk),
+        .rst(rst),
+        .data_in(data_in),
+        .S5(S5),
+        .S6(S6),
+        .data_out(data_out)
+    );
+
+    always #5 clk = ~clk;
+
+    initial begin
+        clk = 0;
+        rst = 1;
+        data_in = 0;
+        S5 = 0; S6 = 0;
+
+        for (i = 0; i < 54; i = i + 1)
+            pipe[i] = 0;
+        for (i = 0; i < 100; i = i + 1) begin
+            data_queue[i] = 0;
+            S5_queue[i] = 0;
+            S6_queue[i] = 0;
+            delay_queue[i] = -1;
+        end
+
+        #15 rst = 0;
+
+        fd_in = $fopen(`PATTERN_FILE, "r");
+        fd_out = $fopen(`RESULT_FILE, "w");
+
+        if (fd_in == 0) begin
+            $display("[ERROR] Cannot open pattern file!");
+            $finish;
+        end
+
+        for (i = 0; i < `NUM_PATTERNS; i = i + 1) begin
+            @(negedge clk);
+            if ($fscanf(fd_in, "%d %b %b\n", data_in, S5, S6) != 3) begin
+                $display("[ERROR] Unexpected EOF at pattern %0d", i);
+                $finish;
+            end
+
+            for (j = 53; j > 0; j = j - 1)
+                pipe[j] = pipe[j-1];
+            pipe[0] = data_in;
+
+            // Store current values into queue
+            data_queue[q_tail] = data_in;
+            S5_queue[q_tail] = S5;
+            S6_queue[q_tail] = S6;
+
+            case (S6)
+                2'b00: begin
+                    case (S5)
+                        2'b00: local_delay = 21;
+                        2'b01: local_delay = 36;
+                        2'b10: local_delay = 54;
+                        default: local_delay = 1;
+                    endcase
+                end
+                2'b01: local_delay = 6;
+                2'b10: local_delay = 18;
+                2'b11: local_delay = 21;
+                default: local_delay = 1;
+            endcase
+
+            delay_queue[q_tail] = local_delay;
+            q_tail = (q_tail + 1) % 100;
+
+            @(posedge clk); #1;
+
+            if (delay_queue[q_head] > 0)
+                delay_queue[q_head] = delay_queue[q_head] - 1;
+
+            if (delay_queue[q_head] == 0 && i >= 54) begin
+                case (S6_queue[q_head])
+                    2'b00: begin
+                        case (S5_queue[q_head])
+                            2'b00: expected_out = pipe[20];
+                            2'b01: expected_out = pipe[35];
+                            2'b10: expected_out = pipe[53];
+                            default: expected_out = 0;
+                        endcase
+                    end
+                    2'b01: expected_out = pipe[5];
+                    2'b10: expected_out = pipe[17];
+                    2'b11: expected_out = pipe[20];
+                    default: expected_out = 0;
+                endcase
+
+                if (data_out !== expected_out) begin
+                    $display("[FAIL] Pattern %0d: data_out=%0d, expected=%0d", i, data_out, expected_out);
+                    $display("        --> Delay=%0d, pipe20=%0d, pipe35=%0d, pipe53=%0d, S5=%b, S6=%b",
+                             delay_queue[q_head], pipe[20], pipe[35], pipe[53], S5_queue[q_head], S6_queue[q_head]);
+                    err_count = err_count + 1;
+                end else begin
+                    $display("[PASS] Pattern %0d: data_out=%0d", i, data_out);
+                end
+                delay_queue[q_head] = -1;
+                q_head = (q_head + 1) % 100;
+            end
+
+            $fwrite(fd_out, "%d\n", data_out);
+        end
+
+        $fclose(fd_in);
+        $fclose(fd_out);
+
+        $display("[DONE] Simulation finished. Total errors: %0d", err_count);
+        #10 $finish;
+    end
+
+    initial begin
+        $dumpfile("control_buffer_tb.vcd");
+        $dumpvars(0, control_buffer_tb);
+    end
+endmodule

--- a/tb/tb_mac_unit_int16.v
+++ b/tb/tb_mac_unit_int16.v
@@ -1,0 +1,79 @@
+`timescale 1ns/1ps
+
+`define PATTERN "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/mac_int_test_patterns.txt"
+`define PATTERN_NUM 20  // Dòng 10-19 chứa dữ liệu 16-bit
+
+module mac_unit_int16_tb;
+
+    localparam N = 16;
+    localparam SUM_WIDTH = (N * 2) + 4;
+
+    reg clk, rst;
+    reg signed [N-1:0] xin_16, win_16;
+    reg signed [SUM_WIDTH-1:0] acc_in_16;
+    reg signed [SUM_WIDTH-1:0] expected;
+    reg [255:0] dummy_line;
+
+    wire signed [SUM_WIDTH-1:0] mac_out_16;
+    wire signed [N-1:0] xout_16;
+
+    integer i, fd, err_count = 0;
+    integer bit_width;
+
+    mac_unit #(.n(N), .SUM_WIDTH(SUM_WIDTH)) DUT (
+        .clk(clk),
+        .rst(rst),
+        .xin(xin_16),
+        .win(win_16),
+        .acc_in(acc_in_16),
+        .mac_out(mac_out_16),
+        .xout(xout_16)
+    );
+
+    always #5 clk = ~clk;
+
+    initial begin
+        fd = $fopen(`PATTERN, "r");
+        if (fd == 0) begin
+            $display("ERROR: Cannot open pattern file.");
+            $finish;
+        end
+
+        clk = 0;
+        rst = 1;
+        #20 rst = 0;
+
+        err_count = 0;
+
+        // Bỏ qua 10 dòng đầu (8-bit)
+        for (i = 0; i < 10; i = i + 1)
+            $fgets(dummy_line, fd);
+
+        for (i = 10; i < `PATTERN_NUM; i = i + 1) begin
+            $fscanf(fd, "%d %d %d %d %d\n", xin_16, win_16, acc_in_16, expected, bit_width);
+
+            #10;
+
+            $display("[INFO] Test %0d: Xin=%0d, Win=%0d, ACC_IN=%0d, Mode=16", i, xin_16, win_16, acc_in_16);
+
+            if (mac_out_16 !== expected) begin
+                err_count = err_count + 1;
+                $display("[ERROR] Expected=%0d but actual=%0d", expected, mac_out_16);
+            end else begin
+                $display("[INFO] Expect=%0d and actual=%0d", expected, mac_out_16);
+            end
+
+            $display("----------------------------");
+        end
+
+        $display("Done. Total errors: %d", err_count);
+        $fclose(fd);
+        #10 $finish;
+    end
+
+    initial begin
+        $dumpfile("mac_unit_int16_tb.vcd");
+        $dumpvars(0, mac_unit_int16_tb);
+    end
+
+endmodule

--- a/tb/tb_mac_unit_int32.v
+++ b/tb/tb_mac_unit_int32.v
@@ -1,0 +1,79 @@
+`timescale 1ns/1ps
+
+`define PATTERN "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/mac_int_test_patterns.txt"
+`define PATTERN_NUM 30  // Dòng 20-29 chứa dữ liệu 32-bit
+
+module mac_unit_int32_tb;
+
+    localparam N = 32;
+    localparam SUM_WIDTH = (N * 2) + 4;
+
+    reg clk, rst;
+    reg signed [N-1:0] xin_32, win_32;
+    reg signed [SUM_WIDTH-1:0] acc_in_32;
+    reg signed [SUM_WIDTH-1:0] expected;
+    reg [255:0] dummy_line;
+
+    wire signed [SUM_WIDTH-1:0] mac_out_32;
+    wire signed [N-1:0] xout_32;
+
+    integer i, fd, err_count = 0;
+    integer bit_width;
+
+    mac_unit #(.n(N), .SUM_WIDTH(SUM_WIDTH)) DUT (
+        .clk(clk),
+        .rst(rst),
+        .xin(xin_32),
+        .win(win_32),
+        .acc_in(acc_in_32),
+        .mac_out(mac_out_32),
+        .xout(xout_32)
+    );
+
+    always #5 clk = ~clk;
+
+    initial begin
+        fd = $fopen(`PATTERN, "r");
+        if (fd == 0) begin
+            $display("ERROR: Cannot open pattern file.");
+            $finish;
+        end
+
+        clk = 0;
+        rst = 1;
+        #20 rst = 0;
+
+        err_count = 0;
+
+        // Bỏ qua 20 dòng đầu (8-bit + 16-bit)
+        for (i = 0; i < 20; i = i + 1)
+            $fgets(dummy_line, fd);
+
+        for (i = 20; i < `PATTERN_NUM; i = i + 1) begin
+            $fscanf(fd, "%d %d %d %d %d\n", xin_32, win_32, acc_in_32, expected, bit_width);
+
+            #10;
+
+            $display("[INFO] Test %0d: Xin=%0d, Win=%0d, ACC_IN=%0d, Mode=32", i, xin_32, win_32, acc_in_32);
+
+            if (mac_out_32 !== expected) begin
+                err_count = err_count + 1;
+                $display("[ERROR] Expected=%0d but actual=%0d", expected, mac_out_32);
+            end else begin
+                $display("[INFO] Expect=%0d and actual=%0d", expected, mac_out_32);
+            end
+
+            $display("----------------------------");
+        end
+
+        $display("Done. Total errors: %d", err_count);
+        $fclose(fd);
+        #10 $finish;
+    end
+
+    initial begin
+        $dumpfile("mac_unit_int32_tb.vcd");
+        $dumpvars(0, mac_unit_int32_tb);
+    end
+
+endmodule

--- a/tb/tb_mac_unit_int8.v
+++ b/tb/tb_mac_unit_int8.v
@@ -1,0 +1,75 @@
+`timescale 1ns/1ps
+
+`define PATTERN "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/mac_int_test_patterns.txt"
+`define PATTERN_NUM 10
+
+module mac_unit_int8_tb;
+
+    localparam N = 8;
+    localparam SUM_WIDTH = (N * 2) + 4;
+
+    reg clk, rst;
+    reg signed [N-1:0] xin_8, win_8;
+    reg signed [SUM_WIDTH-1:0] acc_in_8;
+
+    wire signed [SUM_WIDTH-1:0] mac_out_8;
+    wire signed [N-1:0] xout_8;
+
+    reg signed [SUM_WIDTH-1:0] expected;
+    integer i, fd, err_count = 0;
+    integer bit_width;
+
+    // Instantiate MAC Unit
+    mac_unit #(.n(N), .SUM_WIDTH(SUM_WIDTH)) DUT (
+        .clk(clk),
+        .rst(rst),
+        .xin(xin_8),
+        .win(win_8),
+        .acc_in(acc_in_8),
+        .mac_out(mac_out_8),
+        .xout(xout_8)
+    );
+
+    always #5 clk = ~clk;
+
+    initial begin
+        fd = $fopen(`PATTERN, "r");
+        if (fd == 0) begin
+            $display("ERROR: Cannot open pattern file: %s", `PATTERN);
+            $finish;
+        end
+
+        clk = 0;
+        rst = 1;
+        #20 rst = 0;
+
+        err_count = 0;
+
+        for (i = 0; i < `PATTERN_NUM; i = i + 1) begin
+            $fscanf(fd, "%d %d %d %d %d\n", xin_8, win_8, acc_in_8, expected, bit_width);
+
+            #10;
+
+            $display("[INFO] Test %0d: Xin=%0d, Win=%0d, ACC_IN=%0d, Mode=8", i, xin_8, win_8, acc_in_8);
+
+            if (mac_out_8 !== expected) begin
+                err_count = err_count + 1;
+                $display("[ERROR] Mismatch! Expected=%0d but actual=%0d", expected, mac_out_8);
+            end else begin
+                $display("[INFO] Passed. Expected=%0d with actual=%0d", expected, mac_out_8);
+            end
+
+            $display("----------------------------");
+        end
+
+        $display("Test done. Total errors: %d", err_count);
+        $fclose(fd);
+        #10 $finish;
+    end
+
+    initial begin
+        $dumpfile("mac_unit_int8_tb.vcd");
+        $dumpvars(0, mac_unit_int8_tb);
+    end
+
+endmodule

--- a/tb/tb_maxpooling.v
+++ b/tb/tb_maxpooling.v
@@ -1,0 +1,79 @@
+`timescale 1ns/1ps
+`define PATTERN_FILE "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/maxpool_test_patterns.txt"
+`define NUM_PATTERNS 30
+
+module maxpooling_tb;
+
+    localparam WIDTH = 32;
+
+    reg clk, rst, S3;
+    reg signed [WIDTH-1:0] din;
+    wire signed [WIDTH-1:0] dout;
+
+    integer fd, i, ret;
+    integer err_count = 0;
+    reg signed [WIDTH-1:0] expected_output;
+
+    // Input values read from file (applied over 3 clock cycles)
+    reg signed [WIDTH-1:0] r1_val, r2_val, r3_val;
+
+    // Instantiate DUT
+    MaxPooling #(.WIDTH(WIDTH)) dut (
+        .clk(clk),
+        .rst(rst),
+        .data_in(din),
+        .S3(S3),
+        .data_out(dout)
+    );
+
+    // Clock
+    always #5 clk = ~clk;
+
+    initial begin
+        clk = 0;
+        rst = 1; #10; rst = 0;
+
+        fd = $fopen(`PATTERN_FILE, "r");
+        if (fd == 0) begin
+            $display("[FATAL] Cannot open pattern file.");
+            $finish;
+        end
+
+        for (i = 0; i < `NUM_PATTERNS; i = i + 1) begin
+            ret = $fscanf(fd, "%d %d %d %d %d\n", r1_val, r2_val, r3_val, S3, expected_output);
+            if (ret != 5) begin
+                $display("[ERROR] Pattern line %0d malformed (ret = %0d)", i, ret);
+                $finish;
+            end
+
+            // Apply inputs in reverse order due to register pipeline
+            @(posedge clk); din = r3_val;
+            @(posedge clk); din = r2_val;
+            @(posedge clk); din = r1_val;
+
+            @(posedge clk); // wait one extra cycle for pipeline to settle
+
+            $display("Test %0d: Inputs={%0d, %0d, %0d}, S3=%d", 
+                i, r1_val, r2_val, r3_val, S3);
+
+            if (dout !== expected_output) begin
+                $display("[ERROR] Expected=%0d and Actual=%0d ==> Mismactch", expected_output, dout);
+                err_count = err_count + 1;
+            end
+            else begin
+                $display("[INFO] Expected=%0d and Actual=%0d ==> Matching", expected_output, dout);
+            end 
+        end
+
+        $fclose(fd);
+        $display("Test completed. Total errors: %0d", err_count);
+        repeat (5) @(posedge clk);
+        $finish;
+    end
+
+    initial begin
+        $dumpfile("maxpooling_tb.vcd");
+        $dumpvars(0, maxpooling_tb);
+    end
+
+endmodule

--- a/tb/tb_pe_16bit.v
+++ b/tb/tb_pe_16bit.v
@@ -1,0 +1,87 @@
+`timescale 1ns/1ps
+
+`define PATTERN "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/pe_test_patterns.txt"
+`define PATTERN_NUM 10  // Dòng 10-19: 16-bit patterns
+
+module pe_int16_tb;
+
+    localparam N = 16;
+    localparam SUM_WIDTH = (N * 2) + 4;
+
+    reg clk, rst;
+    reg signed [N-1:0] xin, w0, w1, w2, w3, w4, w5, w6;
+    reg signed [SUM_WIDTH-1:0] expected_sum, expected_sum1;
+    reg signed [N*7-1:0] win_packed;
+
+    wire signed [SUM_WIDTH-1:0] sum, sum1;
+    wire signed [N-1:0] xout;
+
+    integer i, fd, err_count = 0;
+    integer bit_width;
+
+    // Instantiate DUT
+    PE #(.n(N), .SUM_WIDTH(SUM_WIDTH)) DUT (
+        .clk(clk),
+        .rst(rst),
+        .xin(xin),
+        .win(win_packed),
+        .sum(sum),
+        .sum1(sum1),
+        .xout(xout)
+    );
+
+    // Clock 100MHz
+    always #5 clk = ~clk;
+
+    initial begin
+        fd = $fopen(`PATTERN, "r");
+        if (fd == 0) begin
+            $display("ERROR: Cannot open pattern file.");
+            $finish;
+        end
+
+        clk = 0;
+        rst = 0;
+        err_count = 0;
+
+        // Skip 10 dòng đầu (8-bit)
+        for (i = 0; i < 10; i = i + 1)
+            $fscanf(fd, "%*d %*d %*d %*d %*d %*d %*d %*d %*d %*d %*d\n");
+
+        for (i = 0; i < `PATTERN_NUM; i = i + 1) begin
+            $fscanf(fd, "%d %d %d %d %d %d %d %d %d %d %d\n",
+                    xin, w0, w1, w2, w3, w4, w5, w6,
+                    expected_sum, expected_sum1, bit_width);
+
+            rst = 1; #10; rst = 0;
+            win_packed = {w6, w5, w4, w3, w2, w1, w0};
+
+            repeat (9) @(posedge clk);
+
+            $display("[INFO] Test %0d (bit-width=%0d)", i + 10, bit_width);
+            $display("       Xin=%0d, Weights={%0d,%0d,%0d,%0d,%0d,%0d,%0d}",
+                      xin, w0, w1, w2, w3, w4, w5, w6);
+
+            if (sum !== expected_sum || sum1 !== expected_sum1) begin
+                err_count = err_count + 1;
+                $display("[ERROR] Expected: sum=%0d, sum1=%0d not match with Actual: sum=%0d, sum1=%0d",
+                         expected_sum, expected_sum1, sum, sum1);
+            end else begin
+                $display("[INFO] Expected: sum=%0d, sum1=%0d is matching with Actual: sum=%0d, sum1=%0d",
+                         expected_sum, expected_sum1, sum, sum1);
+            end
+
+            $display("----------------------------");
+        end
+
+        $display("Test done. Total errors: %0d", err_count);
+        $fclose(fd);
+        #10 $finish;
+    end
+
+    initial begin
+        $dumpfile("pe_int16_tb.vcd");
+        $dumpvars(0, pe_int16_tb);
+    end
+
+endmodule

--- a/tb/tb_pe_32bit.v
+++ b/tb/tb_pe_32bit.v
@@ -1,0 +1,88 @@
+`timescale 1ns/1ps
+
+`define PATTERN "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/pe_test_patterns.txt"
+`define PATTERN_NUM 10  // Dòng 20-29: 32-bit patterns
+
+module pe_int32_tb;
+
+    localparam N = 32;
+    localparam SUM_WIDTH = (N * 2) + 4;
+
+    reg clk, rst;
+    reg signed [N-1:0] xin, w0, w1, w2, w3, w4, w5, w6;
+    reg signed [SUM_WIDTH-1:0] expected_sum, expected_sum1;
+    reg signed [N*7-1:0] win_packed;
+
+    wire signed [SUM_WIDTH-1:0] sum, sum1;
+    wire signed [N-1:0] xout;
+
+    integer i, fd, err_count = 0;
+    integer bit_width;
+
+    // Instantiate DUT
+    PE #(.n(N), .SUM_WIDTH(SUM_WIDTH)) DUT (
+        .clk(clk),
+        .rst(rst),
+        .xin(xin),
+        .win(win_packed),
+        .sum(sum),
+        .sum1(sum1),
+        .xout(xout)
+    );
+
+    // Clock 100MHz
+    always #5 clk = ~clk;
+
+    initial begin
+        fd = $fopen(`PATTERN, "r");
+        if (fd == 0) begin
+            $display("ERROR: Cannot open pattern file.");
+            $finish;
+        end
+
+        clk = 0;
+        rst = 0;
+        err_count = 0;
+
+        // Skip 20 lines: 10 for 8-bit + 10 for 16-bit
+        for (i = 0; i < 20; i = i + 1)
+            $fscanf(fd, "%*d %*d %*d %*d %*d %*d %*d %*d %*d %*d %*d\n");
+
+        // Read and test 10 patterns (lines 20-29)
+        for (i = 0; i < `PATTERN_NUM; i = i + 1) begin
+            $fscanf(fd, "%d %d %d %d %d %d %d %d %d %d %d\n",
+                    xin, w0, w1, w2, w3, w4, w5, w6,
+                    expected_sum, expected_sum1, bit_width);
+
+            rst = 1; #10; rst = 0;
+            win_packed = {w6, w5, w4, w3, w2, w1, w0};
+
+            repeat (9) @(posedge clk);
+
+            $display("[INFO] Test %0d (bit-width=%0d)", i + 20, bit_width);
+            $display("       Xin=%0d, Weights={%0d,%0d,%0d,%0d,%0d,%0d,%0d}",
+                     xin, w0, w1, w2, w3, w4, w5, w6);
+
+            if (sum !== expected_sum || sum1 !== expected_sum1) begin
+                err_count = err_count + 1;
+                $display("[ERROR] Expected: sum=%0d, sum1=%0d not match with Actual: sum=%0d, sum1=%0d",
+                         expected_sum, expected_sum1, sum, sum1);
+            end else begin
+                $display("[INFO] Expected: sum=%0d, sum1=%0d is matching with Actual: sum=%0d, sum1=%0d",
+                         expected_sum, expected_sum1, sum, sum1);
+            end
+
+            $display("----------------------------");
+        end
+
+        $display("Test done. Total errors: %0d", err_count);
+        $fclose(fd);
+        #10 $finish;
+    end
+
+    initial begin
+        $dumpfile("pe_int32_tb.vcd");
+        $dumpvars(0, pe_int32_tb);
+    end
+
+endmodule

--- a/tb/tb_pe_8bit.v
+++ b/tb/tb_pe_8bit.v
@@ -1,0 +1,89 @@
+`timescale 1ns/1ps
+
+`define PATTERN "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/pe_test_patterns.txt"
+`define PATTERN_NUM 10
+
+module pe_int8_tb;
+
+    localparam N = 8;
+    localparam SUM_WIDTH = (N * 2) + 4;
+
+    reg clk, rst;
+    reg signed [N-1:0] xin_8, w0, w1, w2, w3, w4, w5, w6;
+    reg signed [SUM_WIDTH-1:0] expected_sum, expected_sum1;
+    reg signed [N*7-1:0] win_packed;
+
+    wire signed [SUM_WIDTH-1:0] sum, sum1;
+    wire signed [N-1:0] xout_8;
+
+    integer i, fd, err_count = 0;
+    integer bit_width;
+
+    // Instantiate PE
+    PE #(.n(N), .SUM_WIDTH(SUM_WIDTH)) DUT (
+        .clk(clk),
+        .rst(rst),
+        .xin(xin_8),
+        .win(win_packed),
+        .sum(sum),
+        .sum1(sum1),
+        .xout(xout_8)
+    );
+
+    // Clock 100MHz
+    always #5 clk = ~clk;
+
+    initial begin
+        fd = $fopen(`PATTERN, "r");
+        if (fd == 0) begin
+            $display("ERROR: Cannot open pattern file: %s", `PATTERN);
+            $finish;
+        end
+
+        clk = 0;
+        rst = 1;
+        #20 rst = 0;
+        err_count = 0;
+
+        for (i = 0; i < `PATTERN_NUM; i = i + 1) begin
+            // Đọc 11 giá trị từ file (xin, w0..w6, expected_sum, expected_sum1, bit_width)
+            $fscanf(fd, "%d %d %d %d %d %d %d %d %d %d %d\n",
+                xin_8, w0, w1, w2, w3, w4, w5, w6,
+                expected_sum, expected_sum1, bit_width);
+
+            // Cấp packed weights
+            win_packed = {w6, w5, w4, w3, w2, w1, w0}; 
+            
+            // Reset hệ thống
+            rst = 1; #10; rst = 0;
+
+            // Chờ pipeline đầy (tối thiểu 7 MACs → 9 chu kỳ cho an toàn)
+            repeat (9) @(posedge clk);
+
+            // So sánh kết quả
+            $display("[INFO] Test %0d: Xin=%0d, Weights={%0d,%0d,%0d,%0d,%0d,%0d,%0d}",
+                     i, xin_8, w0, w1, w2, w3, w4, w5, w6);
+
+            if (sum !== expected_sum || sum1 !== expected_sum1) begin
+                err_count = err_count + 1;
+                $display("[ERROR] Expected: sum=%0d, sum1=%0d not match with Actual: sum=%0d, sum1=%0d",
+                         expected_sum, expected_sum1, sum, sum1);
+            end else begin
+                $display("[INFO] Expected: sum=%0d, sum1=%0d is matching with Actual: sum=%0d, sum1=%0d",
+                         expected_sum, expected_sum1, sum, sum1);
+            end
+
+            $display("-----------------------------");
+        end
+
+        $display("Test done. Total errors: %d", err_count);
+        $fclose(fd);
+        #10 $finish;
+    end
+
+    initial begin
+        $dumpfile("pe_int8_tb.vcd");
+        $dumpvars(0, pe_int8_tb);
+    end
+
+endmodule

--- a/tb/tb_relu.v
+++ b/tb/tb_relu.v
@@ -1,0 +1,79 @@
+`timescale 1ns/1ps
+`define PATTERN_FILE "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/relu_test_patterns.txt"
+`define NUM_PATTERNS 30
+
+module relu_tb;
+
+    localparam WIDTH = 32;
+
+    reg clk, rst, S2;
+    reg signed [WIDTH-1:0] sum, sum1;
+    reg signed [WIDTH-1:0] expected_output;
+    wire signed [WIDTH-1:0] relu_out;
+
+    integer fd, i, err_count, ret;
+    reg stop_test;
+
+    // Instantiate ReLU DUT
+    ReLU #(.WIDTH(WIDTH)) dut (
+        .clk(clk),
+        .rst(rst),
+        .sum(sum),
+        .sum1(sum1),
+        .S2(S2),
+        .relu_out(relu_out)
+    );
+
+    // Clock 100MHz
+    always #5 clk = ~clk;
+
+    initial begin
+        // Init signals
+        clk = 0;
+        rst = 1;
+        err_count = 0;
+        stop_test = 0;
+        #10 rst = 0;
+
+        // Open file
+        fd = $fopen(`PATTERN_FILE, "r");
+        if (fd == 0) begin
+            $display("[FATAL] Cannot open pattern file: %s", `PATTERN_FILE);
+            $finish;
+        end
+
+        // Main pattern loop
+        for (i = 0; i < `NUM_PATTERNS && !stop_test; i = i + 1) begin
+            ret = $fscanf(fd, "%d %d %d %d\n", sum, sum1, S2, expected_output);
+            if (ret != 4) begin
+                $display("[ERROR] fscanf failed at i=%0d (only read %0d items).", i, ret);
+                stop_test = 1;
+            end else begin
+                @(posedge clk);  // cycle 1: apply inputs
+                @(posedge clk);  // cycle 2: reg_1x1 stores value
+                @(posedge clk);  // cycle 3: relu_out ready
+
+                $display("Test %0d: sum=%0d, sum1=%0d, S2=%b", i, sum, sum1, S2);
+
+                if (relu_out !== expected_output) begin
+                    err_count = err_count + 1;
+                    $display("[ERROR] Expected=%0d but got Actual=%0d", expected_output, relu_out);
+                end else begin
+                    $display("[INFO] Expected=%0d and Actual=%0d", expected_output, relu_out);
+                end
+            end
+        end
+
+        $fclose(fd);
+        $display("Test completed. Total errors: %0d", err_count);
+        repeat (10) @(posedge clk);  // chờ thêm vài xung để đảm bảo wave ổn định
+        $finish;
+    end
+
+    // Waveform dump
+    initial begin
+        $dumpfile("relu_tb.vcd");
+        $dumpvars(0, relu_tb);
+    end
+
+endmodule

--- a/tb/tb_softmax.v
+++ b/tb/tb_softmax.v
@@ -1,0 +1,117 @@
+`timescale 1ns/1ps
+
+`define PATTERN_FILE "C:/Users/AD/Thesis_ECG/thesis_ver_07/database/softmax_test_patterns.txt"
+`define NUM_NODES 6
+`define SUM_PER_NODE 3
+`define NUM_TESTS 190
+
+module softmax_tb;
+    localparam WIDTH = 32;
+
+    reg clk, rst;
+    reg accumulate_en, store_en;
+    reg signed [WIDTH-1:0] sum;
+    wire signed [WIDTH-1:0] detection_out;
+
+    integer fd, t, i, j, idx;
+    integer err_count = 0;
+    reg signed [WIDTH-1:0] expected_output;
+    reg signed [WIDTH-1:0] sum_val;
+    reg signed [WIDTH-1:0] all_inputs [0:17];
+
+    // DUT
+    Softmax #(.WIDTH(WIDTH)) dut (
+        .clk(clk),
+        .rst(rst),
+        .sum(sum),
+        .accumulate_en(accumulate_en),
+        .store_en(store_en),
+        .detection_out(detection_out)
+    );
+
+    // Clock
+    always #5 clk = ~clk;
+
+    initial begin
+        clk = 0;
+        rst = 1; accumulate_en = 0; store_en = 0; sum = 0;
+        #12 rst = 0;
+
+        fd = $fopen(`PATTERN_FILE, "r");
+        if (fd == 0) begin
+            $display("[ERROR] Cannot open pattern file!");
+            $finish;
+        end
+
+        for (t = 0; t < `NUM_TESTS; t = t + 1) begin
+            $display("========== Test %0d ==========", t);
+
+            // Reset DUT trước mỗi test
+            rst = 1;
+            @(posedge clk);
+            rst = 0;
+            @(posedge clk);
+
+            idx = 0;
+
+            for (i = 0; i < `NUM_NODES; i = i + 1) begin
+                for (j = 0; j < `SUM_PER_NODE; j = j + 1) begin
+                    if ($fscanf(fd, "%d\n", sum_val) != 1) begin
+                        $display("[ERROR] Unexpected EOF when reading sum at test %0d", t);
+                        $finish;
+                    end
+                    sum = sum_val;
+                    all_inputs[idx] = sum_val;  // save input
+                    idx = idx + 1;
+                    @(posedge clk);
+                    accumulate_en = 1;
+                    @(posedge clk);
+                    accumulate_en = 0;
+                    sum = 0;
+                end
+
+                @(posedge clk);
+                store_en = 1;
+                @(posedge clk);
+                store_en = 0;
+            end
+
+            if ($fscanf(fd, "%d\n", expected_output) != 1) begin
+                $display("[ERROR] Unexpected EOF when reading expected_output at test %0d", t);
+                $finish;
+            end
+
+            repeat (3) @(posedge clk); // Đợi detection_out ổn định
+
+            // Display all inputs
+            $display("  [Input sums per node]");
+            for (i = 0; i < `NUM_NODES; i = i + 1) begin
+                $display("    Node %0d: %0d + %0d + %0d",
+                         i,
+                         all_inputs[i*3 + 0],
+                         all_inputs[i*3 + 1],
+                         all_inputs[i*3 + 2]);
+            end
+
+            $display("  => detection_out = %0d", detection_out);
+            $display("  => expected_output = %0d", expected_output);
+
+            if (detection_out !== expected_output) begin
+                $display("[ERROR] Expected=%0d != Actual=%0d", expected_output, detection_out);
+                err_count = err_count + 1;
+            end else begin
+                $display("[PASS] Expected=%0d == Actual=%0d", expected_output, detection_out);
+            end
+        end
+
+        $fclose(fd);
+        $display("Test done. Total errors: %0d", err_count);
+        #10 $finish;
+    end
+
+    initial begin
+        $dumpfile("softmax_tb.vcd");
+        $dumpvars(0, softmax_tb);
+    end
+
+endmodule

--- a/tb/tb_top.v
+++ b/tb/tb_top.v
@@ -1,0 +1,85 @@
+`timescale 1ns/1ps
+
+module ECG_Top_tb;
+    parameter N = 16;
+    parameter SUM_WIDTH = (N*2)+4;
+
+    reg clk, rst, start;
+    reg signed [N-1:0] xin, win;
+    wire signed [N-1:0] detection_out;
+    wire done;
+
+    wire signed [SUM_WIDTH-1:0] sum, sum1;
+    wire signed [SUM_WIDTH-1:0] relu_out, pool_out, ctrl_out;
+    wire [3:0] state;
+
+    // Instantiate DUT
+    ECG_Top #(.N(N), .SUM_WIDTH(SUM_WIDTH)) dut (
+        .clk(clk), .rst(rst), .start(start),
+        .xin(xin), .win(win),
+        .detection_out(detection_out),
+        .done(done),
+        .sum(sum), .sum1(sum1),
+        .relu_out(relu_out),
+        .pool_out(pool_out),
+        .ctrl_out(ctrl_out),
+        .state(state)
+    );
+
+    // Clock generation
+    always #5 clk = ~clk;
+
+    integer i;
+
+    initial begin
+        // Init
+        clk = 0;
+        rst = 1;
+        start = 0;
+        xin = 0;
+        win = 0;
+
+        // Hold reset
+        #20;
+        rst = 0;
+
+        // Trigger start
+        #10;
+        start = 1;
+        #10;
+        start = 0;
+
+        // Feed xin/win only during CONV1/2/3
+        i = 0;
+        while (!done) begin
+            @(negedge clk);
+            if (state == 4'd1 || state == 4'd3 || state == 4'd4) begin // CONV1, CONV2, CONV3
+                xin = i * 10;
+                win = 2;
+                i = i + 1;
+            end else begin
+                xin = 0;
+                win = 0;
+            end
+        end
+
+        // Print final output
+        @(posedge clk);
+        $display("[RESULT] Detection output: %0d", detection_out);
+        #20;
+        $finish;
+    end
+
+    // Debug every cycle
+    always @(posedge clk) begin
+        $display("t=%0t | state=%0d | xin=%0d | win=%0d | sum=%0d | sum1=%0d | relu=%0d | pool=%0d | ctrl=%0d | detect_out=%0d",
+                 $time, state, xin, win, sum, sum1, relu_out, pool_out, ctrl_out, detection_out);
+    end
+
+    // Waveform dump
+    initial begin
+        $dumpfile("ecg_top_tb.vcd");
+        $dumpvars(0, ECG_Top_tb);
+    end
+
+endmodule

--- a/tb/tb_top_multipattern.v
+++ b/tb/tb_top_multipattern.v
@@ -1,0 +1,121 @@
+`timescale 1ns/1ps
+
+module ECG_Top_multi_tb;
+    parameter N = 16;
+    parameter SUM_WIDTH = (N*2)+4;
+    parameter NUM_PATTERNS = 3;
+    parameter MAX_INPUTS = 100; // tối đa per pattern
+
+    reg clk, rst, start;
+    reg signed [N-1:0] xin, win;
+    wire signed [N-1:0] detection_out;
+    wire done;
+
+    wire signed [SUM_WIDTH-1:0] sum, sum1, relu_out, pool_out, ctrl_out;
+    wire [3:0] state;
+
+    // Instantiate DUT
+    ECG_Top #(.N(N), .SUM_WIDTH(SUM_WIDTH)) dut (
+        .clk(clk), .rst(rst), .start(start),
+        .xin(xin), .win(win),
+        .detection_out(detection_out),
+        .done(done),
+        .sum(sum), .sum1(sum1),
+        .relu_out(relu_out),
+        .pool_out(pool_out),
+        .ctrl_out(ctrl_out),
+        .state(state)
+    );
+
+    // Clock
+    always #5 clk = ~clk;
+
+    // Test pattern storage
+    reg signed [N-1:0] xin_pattern[NUM_PATTERNS-1:0][0:MAX_INPUTS-1];
+    reg [7:0] xin_len[NUM_PATTERNS-1:0];
+
+    integer i, p;
+
+    initial begin
+        clk = 0;
+        rst = 1;
+        start = 0;
+        xin = 0;
+        win = 2;
+
+        // Setup test data
+        // Pattern 0: tăng dần
+        for (i = 0; i < 66; i = i + 1)
+            xin_pattern[0][i] = i * 10;
+        xin_len[0] = 66;
+
+        // Pattern 1: giảm dần
+        for (i = 0; i < 66; i = i + 1)
+            xin_pattern[1][i] = 660 - i * 10;
+        xin_len[1] = 66;
+
+        // Pattern 2: sóng hình sin (giả lập)
+        for (i = 0; i < 66; i = i + 1)
+            xin_pattern[2][i] = $rtoi(100.0 * $sin(i * 3.14 / 16.0));
+        xin_len[2] = 66;
+
+        // Wait before start
+        #20;
+        rst = 0;
+        #20;
+
+        // Loop through each pattern
+        for (p = 0; p < NUM_PATTERNS; p = p + 1) begin
+            $display("\n=== PATTERN %0d START ===", p);
+
+            // Reset state
+            start = 1;
+            #10;
+            start = 0;
+
+            i = 0;
+            while (!done) begin
+                @(negedge clk);
+                if (state == 4'd1 || state == 4'd3 || state == 4'd4) begin
+                    if (i < xin_len[p]) begin
+                        xin = xin_pattern[p][i];
+                        i = i + 1;
+                    end else begin
+                        xin = 0;
+                    end
+                end else begin
+                    xin = 0;
+                end
+            end
+
+            // Output
+            @(posedge clk);
+            $display("[PATTERN %0d] DETECTION_OUT = %0d", p, detection_out);
+
+            // Small delay between patterns
+            #20;
+
+            // Reset system for next pattern
+            rst = 1;
+            #20;
+            rst = 0;
+        end
+
+        $display("\n[TEST] Multi-pattern test done.");
+        #20;
+        $finish;
+    end
+
+    // Debug
+    always @(posedge clk) begin
+        $display("t=%0t | st=%0d | xin=%0d | sum=%0d | relu=%0d | pool=%0d | ctrl=%0d | out=%0d",
+            $time, state, xin, sum, relu_out, pool_out, ctrl_out, detection_out);
+    end
+
+    // VCD
+    initial begin
+        $dumpfile("ecg_top_multi.vcd");
+        $dumpvars(0, ECG_Top_multi_tb);
+    end
+
+endmodule


### PR DESCRIPTION
### Summary
Add testbenches for all RTL modules in the CNN accelerator project.

### Added testbenches
- `tb_control_buffer.v`
- `tb_mac_unit_int8.v`
- `tb_mac_unit_int16.v`
- `tb_mac_unit_int32.v`
- `tb_maxpooling.v`
- `tb_pe_8bit.v`
- `tb_pe_16bit.v`
- `tb_pe_32bit.v`
- `tb_relu.v`
- `tb_softmax.v`
- `tb_top.v`
- `tb_top_multipattern.v`

### Purpose
Enable individual and integrated simulation testing of RTL designs.
